### PR TITLE
chart: add cluster auth gate + Gateway API dashboard mode

### DIFF
--- a/chart/kuberik/README.md
+++ b/chart/kuberik/README.md
@@ -58,8 +58,18 @@ helm install kuberik ./chart/kuberik \
 | `integrations.openkruise.enabled` | `false` | Install openkruise-controller |
 | `integrations.environment.enabled` | `false` | Install environment-controller |
 | `dashboard.enabled` | `false` | Install rollout-dashboard |
-| `dashboard.ingress.enabled` | `false` | Expose the dashboard via an Ingress |
+| `dashboard.ingress.enabled` | `false` | Expose the dashboard via a `networking.k8s.io` Ingress |
 | `dashboard.ingress.host` | `""` | Required when ingress is enabled |
+| `dashboard.gateway.enabled` | `false` | Expose the dashboard via a Gateway API HTTPRoute (alternative to `ingress`) |
+| `dashboard.gateway.parentRef.name` | `""` | Gateway the HTTPRoute attaches to |
+| `dashboard.gateway.hostname` | `""` | Hostname the dashboard serves at |
+| `dashboard.gateway.auth` | `false` | Gate the HTTPRoute with the shared `auth` block via a SecurityPolicy |
+| `auth.enabled` | `false` | Install the cluster-level oauth2-proxy auth gate in its own namespace |
+| `auth.oidc.issuerUrl` | `""` | OIDC discovery URL of your IdP |
+| `auth.oidc.clientId` | `kuberik-cluster` | OAuth2 client id; also configure as kube-apiserver `--oidc-client-id` |
+| `auth.canonicalHost` | `""` | Host that owns the OAuth2 callback (`/oauth2/callback`) |
+| `auth.cookieDomain` | _canonicalHost_ | Cookie scope; set a parent domain to share session across subdomains |
+| `auth.gateway.name` | `""` | Gateway the `/oauth2/*` HTTPRoute attaches to |
 | `metrics.serviceMonitor.enabled` | `false` | Prometheus Operator ServiceMonitor for the rollout-controller |
 | `networkPolicy.enabled` | `false` | Restrict ingress/egress for the controller pods |
 | `rolloutController.podDisruptionBudget.enabled` | `false` | Emit a PDB (requires replicas > 1) |
@@ -101,6 +111,39 @@ kubectl delete crd \
 ```
 
 This also deletes every `Rollout`, `RolloutGate`, `HealthCheck`, `RolloutTest`, and `Environment` in the cluster.
+
+### OIDC-gated dashboard (Gateway API)
+
+Put the dashboard behind your OIDC provider via a shared oauth2-proxy in `auth-system`. Same audience works for kube-apiserver, so every dashboard action runs as the logged-in user under RBAC.
+
+```yaml {filename="auth-values.yaml"}
+dashboard:
+  enabled: true
+  gateway:
+    enabled: true
+    parentRef:
+      name: eg
+      namespace: envoy-gateway-system
+    hostname: dashboard.kuberik.example.com
+    auth: true
+
+auth:
+  enabled: true
+  oidc:
+    issuerUrl: https://idp.example.com
+    clientId: kuberik-cluster
+    clientSecret: <your-oidc-client-secret>  # or set existingSecret
+  canonicalHost: dashboard.kuberik.example.com
+  cookieDomain: .example.com
+  gateway:
+    name: eg
+    namespace: envoy-gateway-system
+```
+
+Set kube-apiserver flags:
+`--oidc-issuer-url=https://idp.example.com --oidc-client-id=kuberik-cluster --oidc-username-claim=email`
+
+To gate another service later, add its namespace to `auth.allowedConsumerNamespaces` and apply a `SecurityPolicy` in that namespace pointing at `oauth2-proxy.auth-system:4180`.
 
 ## Enabling everything
 

--- a/chart/kuberik/templates/auth-namespace.yaml
+++ b/chart/kuberik/templates/auth-namespace.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.auth.enabled .Values.auth.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.auth.namespace | quote }}
+  labels:
+    {{- include "kuberik.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auth-gate
+{{- end }}

--- a/chart/kuberik/templates/auth.yaml
+++ b/chart/kuberik/templates/auth.yaml
@@ -1,0 +1,174 @@
+{{- if .Values.auth.enabled }}
+{{- $auth := .Values.auth }}
+{{- if not $auth.oidc.issuerUrl }}{{ fail "auth.oidc.issuerUrl is required when auth.enabled is true" }}{{ end }}
+{{- if not $auth.canonicalHost }}{{ fail "auth.canonicalHost is required when auth.enabled is true (e.g. dashboard.kuberik.example.com)" }}{{ end }}
+{{- if not $auth.gateway.name }}{{ fail "auth.gateway.name is required when auth.enabled is true" }}{{ end }}
+{{- $cookieDomain := default $auth.canonicalHost $auth.cookieDomain }}
+{{- $redirectUrl := printf "https://%s/oauth2/callback" $auth.canonicalHost }}
+{{- $secretName := default (printf "%s-oauth2-proxy" (include "kuberik.name" .)) $auth.oidc.existingSecret }}
+{{- if not $auth.oidc.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $auth.namespace }}
+  labels:
+    {{- include "kuberik.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auth-gate
+type: Opaque
+stringData:
+  client-secret: {{ required "auth.oidc.clientSecret is required when auth.oidc.existingSecret is empty" $auth.oidc.clientSecret | quote }}
+  # Cookie secret is regenerated on every helm upgrade. Pin it via
+  # existingSecret if you need stable sessions across redeploys.
+  cookie-secret: {{ randAlphaNum 32 | b64enc | quote }}
+---
+{{- end }}
+{{- $consumerNamespaces := default (list) $auth.allowedConsumerNamespaces }}
+{{- if and .Values.dashboard.enabled .Values.dashboard.gateway.enabled .Values.dashboard.gateway.auth }}
+{{- $consumerNamespaces = append $consumerNamespaces .Values.namespace }}
+{{- end }}
+{{- $consumerNamespaces = $consumerNamespaces | uniq }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth2-proxy
+  namespace: {{ $auth.namespace }}
+  labels:
+    {{- include "kuberik.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auth-gate
+    app: oauth2-proxy
+spec:
+  replicas: {{ $auth.replicas }}
+  selector:
+    matchLabels:
+      app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app: oauth2-proxy
+        app.kubernetes.io/component: auth-gate
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: {{ printf "%s:%s" $auth.image.repository $auth.image.tag | quote }}
+          imagePullPolicy: {{ $auth.image.pullPolicy }}
+          args:
+            - --provider=oidc
+            - --oidc-issuer-url={{ $auth.oidc.issuerUrl }}
+            - --client-id={{ $auth.oidc.clientId }}
+            - --redirect-url={{ $redirectUrl }}
+            - --scope={{- $scopes := concat (list "openid" "email" "profile" "groups") $auth.oidc.extraScopes }}{{- join " " $scopes }}
+            {{- range $auth.oidc.emailDomains }}
+            - --email-domain={{ . }}
+            {{- end }}
+            - --upstream=static://200
+            - --http-address=0.0.0.0:4180
+            - --set-authorization-header=true
+            - --pass-access-token=true
+            - --set-xauthrequest=true
+            - --skip-provider-button=true
+            - --cookie-secure=true
+            - --cookie-samesite=lax
+            - --cookie-domain={{ $cookieDomain }}
+            - --whitelist-domain={{ $cookieDomain }}
+            - --reverse-proxy=true
+            {{- if $auth.skipJwtBearerTokens }}
+            - --skip-jwt-bearer-tokens=true
+            {{- end }}
+            {{- if $auth.oidc.providerCaConfigMap }}
+            - --provider-ca-file=/etc/ssl/oidc/ca.crt
+            {{- end }}
+            {{- range $auth.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          env:
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: client-secret
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: cookie-secret
+          ports:
+            - containerPort: 4180
+          resources:
+            {{- toYaml $auth.resources | nindent 12 }}
+          {{- if $auth.oidc.providerCaConfigMap }}
+          volumeMounts:
+            - name: oidc-ca
+              mountPath: /etc/ssl/oidc
+              readOnly: true
+          {{- end }}
+      {{- if $auth.oidc.providerCaConfigMap }}
+      volumes:
+        - name: oidc-ca
+          configMap:
+            name: {{ $auth.oidc.providerCaConfigMap }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oauth2-proxy
+  namespace: {{ $auth.namespace }}
+  labels:
+    {{- include "kuberik.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auth-gate
+spec:
+  selector:
+    app: oauth2-proxy
+  ports:
+    - port: 4180
+      targetPort: 4180
+---
+# /oauth2/* serves on every gateway hostname (no hostnames filter) so the 302
+# redirect from extAuth lands on the right subdomain regardless of which app
+# triggered it.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oauth2-proxy
+  namespace: {{ $auth.namespace }}
+  labels:
+    {{- include "kuberik.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auth-gate
+spec:
+  parentRefs:
+    - name: {{ $auth.gateway.name | quote }}
+      {{- with $auth.gateway.namespace }}
+      namespace: {{ . | quote }}
+      {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /oauth2
+      backendRefs:
+        - name: oauth2-proxy
+          port: 4180
+{{- range $ns := $consumerNamespaces }}
+---
+# Lets SecurityPolicies in {{ $ns }} reference oauth2-proxy in
+# {{ $auth.namespace }} as their extAuth backend.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: oauth2-proxy-from-{{ $ns }}
+  namespace: {{ $auth.namespace }}
+  labels:
+    {{- include "kuberik.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: auth-gate
+spec:
+  from:
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: {{ $ns | quote }}
+  to:
+    - group: ""
+      kind: Service
+      name: oauth2-proxy
+{{- end }}
+{{- end }}

--- a/chart/kuberik/templates/dashboard-gateway.yaml
+++ b/chart/kuberik/templates/dashboard-gateway.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.gateway.enabled }}
+{{- $gw := .Values.dashboard.gateway }}
+{{- if not $gw.parentRef.name }}{{ fail "dashboard.gateway.parentRef.name is required when dashboard.gateway.enabled is true" }}{{ end }}
+{{- if not $gw.hostname }}{{ fail "dashboard.gateway.hostname is required when dashboard.gateway.enabled is true" }}{{ end }}
+{{- if and .Values.dashboard.ingress.enabled $gw.enabled }}{{ fail "Set either dashboard.ingress.enabled or dashboard.gateway.enabled, not both." }}{{ end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rollout-dashboard
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kuberik.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-dashboard
+spec:
+  parentRefs:
+    - name: {{ $gw.parentRef.name | quote }}
+      {{- with $gw.parentRef.namespace }}
+      namespace: {{ . | quote }}
+      {{- end }}
+  hostnames:
+    - {{ $gw.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: rollout-dashboard
+          port: 80
+{{- if $gw.auth }}
+{{- if not .Values.auth.enabled }}{{ fail "dashboard.gateway.auth is true but auth.enabled is false" }}{{ end }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: rollout-dashboard-auth
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kuberik.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-dashboard
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: rollout-dashboard
+  extAuth:
+    http:
+      backendRefs:
+        - name: oauth2-proxy
+          namespace: {{ .Values.auth.namespace | quote }}
+          port: 4180
+      headersToBackend:
+        - Authorization
+        - X-Auth-Request-User
+        - X-Auth-Request-Email
+        - X-Auth-Request-Access-Token
+{{- end }}
+{{- end }}

--- a/chart/kuberik/values.schema.json
+++ b/chart/kuberik/values.schema.json
@@ -54,7 +54,65 @@
     },
     "dashboard": {
       "type": "object",
-      "properties": { "enabled": { "type": "boolean" } }
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "parentRef": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "namespace": { "type": "string" }
+              }
+            },
+            "hostname": { "type": "string" },
+            "auth": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "namespace": { "type": "string" },
+        "createNamespace": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "oidc": {
+          "type": "object",
+          "properties": {
+            "issuerUrl": { "type": "string" },
+            "clientId": { "type": "string" },
+            "clientSecret": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "extraScopes": { "type": "array", "items": { "type": "string" } },
+            "emailDomains": { "type": "array", "items": { "type": "string" } },
+            "providerCaConfigMap": { "type": "string" }
+          }
+        },
+        "canonicalHost": { "type": "string" },
+        "cookieDomain": { "type": "string" },
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "namespace": { "type": "string" }
+          }
+        },
+        "allowedConsumerNamespaces": { "type": "array", "items": { "type": "string" } },
+        "skipJwtBearerTokens": { "type": "boolean" },
+        "extraArgs": { "type": "array", "items": { "type": "string" } }
+      }
     },
     "metrics": {
       "type": "object",

--- a/chart/kuberik/values.yaml
+++ b/chart/kuberik/values.yaml
@@ -132,6 +132,88 @@ dashboard:
     #     - hosts: [dashboard.kuberik.example.com]
     #       secretName: dashboard-tls
     tls: []
+  # Gateway API alternative to .ingress. Emits an HTTPRoute (and, when
+  # gateway.auth is true and the cluster auth gate is enabled below, a
+  # SecurityPolicy that gates the dashboard via oauth2-proxy).
+  # Mutually exclusive with .ingress.
+  gateway:
+    enabled: false
+    parentRef:
+      # Gateway to attach the HTTPRoute to. e.g. name: eg, namespace: envoy-gateway-system
+      name: ""
+      namespace: ""
+    # Hostname the dashboard serves at. e.g. "dashboard.kuberik.example.com"
+    hostname: ""
+    # When true, also emit a SecurityPolicy that routes every request
+    # through .Values.auth.* via extAuth. Requires auth.enabled.
+    auth: false
+
+# Cluster-level OIDC auth gate. Installs oauth2-proxy in its own namespace
+# as shared infrastructure; any HTTPRoute (the dashboard above, plus anything
+# else you put on the same Gateway) can opt in via a SecurityPolicy that
+# references it through the ReferenceGrants emitted alongside.
+#
+# The auth gate is dashboard-agnostic - oauth2-proxy never sees upstream
+# backends. To put the dashboard behind it, also set:
+#   dashboard.gateway.enabled: true
+#   dashboard.gateway.auth: true
+auth:
+  enabled: false
+  # Namespace for the shared auth infrastructure. Defaults to auth-system.
+  namespace: auth-system
+  # Have the chart emit the auth namespace. Set false if you manage it
+  # outside the chart (Argo CD, separate kustomize, etc.).
+  createNamespace: true
+  image:
+    repository: quay.io/oauth2-proxy/oauth2-proxy
+    tag: v7.7.1
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources:
+    requests: { cpu: 10m, memory: 64Mi }
+    limits:   { cpu: 200m, memory: 128Mi }
+  # OIDC client config. The same clientId should also be configured as
+  # kube-apiserver's --oidc-client-id so the dashboard's id_token authenticates
+  # against both oauth2-proxy and the API server with one audience.
+  oidc:
+    issuerUrl: ""              # e.g. https://your-idp.example.com
+    clientId: kuberik-cluster
+    # Either set clientSecret inline (NOT recommended for production - it
+    # ends up in the rendered manifest) or point to an existing Secret with
+    # `client-secret` and `cookie-secret` keys.
+    clientSecret: ""
+    existingSecret: ""
+    # Extra OAuth2 scopes appended to "openid email profile groups".
+    extraScopes: []
+    # Restrict accepted email domains. Use ["*"] for any.
+    emailDomains: ["*"]
+    # Trust the OIDC provider's CA (when self-signed). Provide the name of
+    # a ConfigMap in .Values.auth.namespace with a `ca.crt` key.
+    providerCaConfigMap: ""
+  # Canonical host that owns the OAuth2 callback URI - the only one the
+  # OIDC provider needs registered as a redirect URI. All gated subdomains
+  # share the session via .cookieDomain.
+  canonicalHost: ""
+  # Cookie scope. Defaults to canonicalHost. Set to a parent domain
+  # (".example.com") so subdomains share the session.
+  cookieDomain: ""
+  # The Gateway the /oauth2/* HTTPRoute attaches to. Usually the same one
+  # the dashboard uses. The HTTPRoute matches on every gateway hostname
+  # so the 302 redirect lands on whichever subdomain triggered the flow.
+  gateway:
+    name: ""
+    namespace: ""
+  # Namespaces whose SecurityPolicies are allowed to extAuth-reference
+  # oauth2-proxy in this namespace. Emits one ReferenceGrant per entry.
+  # The chart auto-adds .Values.namespace when dashboard.gateway.auth is true.
+  allowedConsumerNamespaces: []
+  # Accept JWT bearer tokens signed by the configured issuer without a
+  # session cookie. Required for multi-cluster hub->spoke fan-out and any
+  # programmatic caller that already holds an id_token.
+  skipJwtBearerTokens: true
+  # Extra command-line args appended to oauth2-proxy. Useful for tweaks
+  # like --whitelist-domain, --upstream-timeout, etc.
+  extraArgs: []
 
 # Common pod settings applied to all controllers.
 podSecurityContext:


### PR DESCRIPTION
## Summary
New \`auth.*\` block installs oauth2-proxy as shared cluster infrastructure in \`auth-system\`. Any HTTPRoute opts in via a \`SecurityPolicy\` that backendRef's it through the \`ReferenceGrant\` the chart emits. Provider-agnostic — one OIDC client id is reused by kube-apiserver as \`--oidc-client-id\`, so the same id_token authenticates against both oauth2-proxy and the API server without Dex-specific cross-client trickery.

\`dashboard.gateway.*\` is an opt-in Gateway API alternative to the existing \`dashboard.ingress\` block. When \`dashboard.gateway.auth: true\`, the chart attaches the dashboard to the auth gate.

Both new blocks are off by default. Existing ingress-mode dashboard installs are unchanged.

## Example

\`\`\`yaml
dashboard:
  enabled: true
  gateway:
    enabled: true
    parentRef: { name: eg, namespace: envoy-gateway-system }
    hostname: dashboard.kuberik.example.com
    auth: true

auth:
  enabled: true
  oidc:
    issuerUrl: https://idp.example.com
    clientId: kuberik-cluster
    clientSecret: <oidc-client-secret>
  canonicalHost: dashboard.kuberik.example.com
  cookieDomain: .example.com
  gateway: { name: eg, namespace: envoy-gateway-system }
\`\`\`

Configure kube-apiserver with \`--oidc-client-id=kuberik-cluster\` and the same issuer.

## Validation
- \`auth.enabled\` requires \`oidc.issuerUrl\`, \`canonicalHost\`, \`gateway.name\`
- \`dashboard.gateway.enabled\` requires \`parentRef.name\`, \`hostname\`
- \`dashboard.gateway.auth\` requires \`auth.enabled\`
- \`ingress.enabled\` and \`gateway.enabled\` are mutually exclusive

Verified by \`helm template\` rendering the full topology and rejecting each missing required field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)