### PR TITLE
chart 0.5.1: bump dashboard v0.8.2

### DIFF
--- a/chart/kuberik/Chart.yaml
+++ b/chart/kuberik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kuberik
 description: Kubernetes-native progressive delivery. Installs the Kuberik rollout-controller and optional integration controllers.
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.8.0"
 home: https://kuberik.com
 sources:

--- a/chart/kuberik/templates/dashboard.yaml
+++ b/chart/kuberik/templates/dashboard.yaml
@@ -136,7 +136,7 @@ spec:
         app: rollout-dashboard
     spec:
       containers:
-        - image: {{ printf "%s:%s" .Values.dashboard.image.repository (.Values.dashboard.image.tag | default "v0.8.0") | quote }}
+        - image: {{ printf "%s:%s" .Values.dashboard.image.repository (.Values.dashboard.image.tag | default "v0.8.1") | quote }}
           name: rollout-dashboard
           ports:
             - containerPort: 8080

--- a/chart/kuberik/templates/dashboard.yaml
+++ b/chart/kuberik/templates/dashboard.yaml
@@ -136,7 +136,7 @@ spec:
         app: rollout-dashboard
     spec:
       containers:
-        - image: {{ printf "%s:%s" .Values.dashboard.image.repository (.Values.dashboard.image.tag | default "v0.8.1") | quote }}
+        - image: {{ printf "%s:%s" .Values.dashboard.image.repository (.Values.dashboard.image.tag | default "v0.8.2") | quote }}
           name: rollout-dashboard
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

Bumps the bundled rollout-dashboard image to **v0.8.2** and the chart `version` to **0.5.1**.

- `chart/kuberik/templates/dashboard.yaml` — default dashboard image tag → `v0.8.2`
- `chart/kuberik/Chart.yaml` — chart `version` `0.5.0` → `0.5.1`

`appVersion` stays `0.8.0` — that tracks the rollout-controller, which did not change.

rollout-dashboard v0.8.2 succeeds v0.8.1; it carries the multi-cluster source-matching fix (kuberik/rollout-dashboard#20) plus follow-ups.

> Note: v0.8.2 is not tagged/published yet — hold merge until the rollout-dashboard v0.8.2 image is pushed to ghcr, or the dashboard pod will fail to pull.

## Test plan

- [x] `helm template chart/kuberik --set dashboard.enabled=true` renders `ghcr.io/kuberik/rollout-dashboard:v0.8.2`
- [ ] Install/upgrade in a cluster and confirm the dashboard pod pulls v0.8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
