### PR TITLE
chore(install): bump component versions (rollout-controller v0.8.0, openkruise v0.4.0)

### DIFF
--- a/config/install/kustomization.yaml
+++ b/config/install/kustomization.yaml
@@ -12,9 +12,9 @@ kind: Kustomization
 
 resources:
   # Core (required)
-  - https://github.com/kuberik/rollout-controller/releases/download/v0.7.0/install.yaml
+  - https://github.com/kuberik/rollout-controller/releases/download/v0.8.0/install.yaml
 
   # Integrations (optional - comment out what you don't need)
-  - https://github.com/kuberik/openkruise-controller/releases/download/v0.3.3/install.yaml
+  - https://github.com/kuberik/openkruise-controller/releases/download/v0.4.0/install.yaml
   - https://github.com/kuberik/datadog-controller/releases/download/v0.1.0/install.yaml
   - https://github.com/kuberik/environment-controller/releases/download/v0.1.5/install.yaml


### PR DESCRIPTION
## Summary
- Bumps `config/install/kustomization.yaml` release URLs:
  - `kuberik/rollout-controller` `v0.7.0` → `v0.8.0`
  - `kuberik/openkruise-controller` `v0.3.3` → `v0.4.0`
- Chart templates already default openkruise to `v0.4.0` and rollout-controller to Chart `appVersion` `0.8.0`, so no chart template edits were needed.

Fixes #5

## Test plan
- [ ] Confirm release assets exist at the new URLs
- [ ] `kubectl kustomize config/install` (or dry-apply) resolves the updated remote resources