### PR TITLE
fix(ci): unblock Dependabot CI action bumps

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -18,7 +18,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.3
 

--- a/.github/workflows/check-component-releases.yaml
+++ b/.github/workflows/check-component-releases.yaml
@@ -13,7 +13,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Diff pinned vs latest component releases
         id: diff

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -31,22 +31,22 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
   manifests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup kustomize
-        uses: imranismail/setup-kustomize@v2
+        uses: imranismail/setup-kustomize@v3
       - name: Build install manifest
         run: kustomize build config/install > /tmp/install.yaml
       - name: Validate YAML
@@ -57,9 +57,9 @@ jobs:
   helm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.3
       - name: Lint chart
@@ -92,9 +92,9 @@ jobs:
       matrix:
         profile: [defaults, integrations]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.3
       - name: Create kind cluster
@@ -178,9 +178,9 @@ jobs:
   helm-upgrade-kind:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.3
       - name: Create kind cluster

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -20,15 +20,15 @@ jobs:
       matrix:
         language: [go]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4.37.3
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@v4.37.3
+      - uses: github/codeql-action/analyze@v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,9 +12,9 @@ jobs:
   cli-on-kind:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -19,8 +19,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v17
+      - uses: actions/checkout@v7
+      - uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           globs: '**/*.md'
           config: .markdownlint.json

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -11,7 +11,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,25 +14,25 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -18,23 +18,23 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           publish_results: true
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           days-before-issue-stale: 90
           days-before-issue-close: 14

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.yaml

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run Trivy filesystem scan
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -31,7 +31,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4.37.3
         if: always()
         with:
           sarif_file: trivy-fs.sarif

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,15 @@
 # golangci-lint configuration for the kuberik CLI.
 # Run locally with: make lint
 
+version: "2"
+
 run:
   timeout: 5m
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - gofmt
-    - goimports
     - govet
     - ineffassign
     - misspell
@@ -17,36 +17,39 @@ linters:
     - staticcheck
     - unconvert
     - unused
-
-linters-settings:
-  revive:
+  settings:
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+          disabled: true
+        - name: unreachable-code
+        - name: redefines-builtin-id
+  exclusions:
     rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: unused-parameter
-        disabled: true
-      - name: unreachable-code
-      - name: redefines-builtin-id
+      - path: _test\.go
+        linters:
+          - revive
 
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - revive
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,9 @@
 {
   "default": true,
   "MD013": false,
-  "MD024": { "siblings_only": true },
+  "MD024": {
+    "siblings_only": true
+  },
   "MD031": false,
   "MD032": false,
   "MD033": false,
@@ -9,6 +11,11 @@
   "MD036": false,
   "MD040": false,
   "MD041": false,
-  "MD046": { "style": "fenced" },
-  "MD007": { "indent": 2 }
+  "MD046": {
+    "style": "fenced"
+  },
+  "MD007": {
+    "indent": 2
+  },
+  "MD060": false
 }

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,5 +16,5 @@ You can also fill in less detail if your legal team requires it - even just an o
 ## Adopters
 
 | Organization | Use case | Since | Link |
-|---|---|---|---|
-| _Add yours here_ | | | |
+| --- | --- | --- | --- |
+| _Add yours here_ |  |  |  |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ For broader questions or design discussion, start a thread in [GitHub Discussion
 ## Where the code lives
 
 | Component | Repository |
-|---|---|
+| --- | --- |
 | Core controller (CRDs, reconcilers) | [rollout-controller](https://github.com/kuberik/rollout-controller) |
 | Web dashboard | [rollout-dashboard](https://github.com/kuberik/rollout-dashboard) |
 | Datadog integration | [datadog-controller](https://github.com/kuberik/datadog-controller) |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Kuberik is declarative, multi-stage progressive delivery for Kubernetes - from c
 ## Features
 
 | Feature | Description |
-|---|---|
+| --- | --- |
 | **Multi-Stage Pipelines** | Promote releases across environments with dependencies between stages. |
 | **Deployment Gates** | Control when and which releases deploy - with schedules, manual approvals, or custom conditions. |
 | **Canary Rollouts** | Gradually roll out changes to a subset of users before full promotion. |
@@ -122,7 +122,7 @@ graph TD
 ## Components
 
 | Component | Purpose |
-|---|---|
+| --- | --- |
 | [rollout-controller](https://github.com/kuberik/rollout-controller) | Core controller. Manages Rollout, RolloutGate, HealthCheck, and RolloutSchedule CRDs. |
 | [rollout-dashboard](https://github.com/kuberik/rollout-dashboard) | Web UI for visualizing rollout status across namespaces. |
 | [datadog-controller](https://github.com/kuberik/datadog-controller) | Creates kuberik HealthCheck resources from DatadogMonitor status. |

--- a/action/README.md
+++ b/action/README.md
@@ -16,11 +16,11 @@ Install the [Kuberik CLI](https://github.com/kuberik/kuberik) on Linux, macOS, o
 
 ## Inputs
 
-| Name      | Description                                                                  | Required |
-|-----------|------------------------------------------------------------------------------|----------|
-| `version` | CLI version (e.g. `0.1.0`). Defaults to latest stable release.               | no       |
-| `bindir`  | Override the install directory. Defaults to a path under `$RUNNER_TOOL_CACHE`. | no       |
-| `token`   | GitHub token for the releases API (avoids rate limits).                      | no       |
+| Name | Description | Required |
+| --- | --- | --- |
+| `version` | CLI version (e.g. `0.1.0`). Defaults to latest stable release. | no |
+| `bindir` | Override the install directory. Defaults to a path under `$RUNNER_TOOL_CACHE`. | no |
+| `token` | GitHub token for the releases API (avoids rate limits). | no |
 
 ## Examples
 

--- a/chart/kuberik/README.md
+++ b/chart/kuberik/README.md
@@ -46,7 +46,7 @@ helm install kuberik ./chart/kuberik \
 ## Values
 
 | Key | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `namespace` | `kuberik-system` | Namespace the controllers run in |
 | `rolloutController.enabled` | `true` | Install the core controller |
 | `rolloutController.image.repository` | `ghcr.io/kuberik/rollout-controller` | Controller image |

--- a/cmd/kuberik/bootstrap.go
+++ b/cmd/kuberik/bootstrap.go
@@ -31,12 +31,12 @@ Skip the Flux install with --flux=false if your cluster already has it.`,
 			return err
 		}
 		if !bootstrapFluxOnly {
-			fmt.Fprintln(cmd.OutOrStderr(), "Installing Flux core (source, kustomize, image-reflector)...")
+			_, _ = fmt.Fprintln(cmd.OutOrStderr(), "Installing Flux core (source, kustomize, image-reflector)...")
 			if err := kubectl("apply", "-f", fluxImageReflectorURL).Run(); err != nil {
 				return fmt.Errorf("flux install: %w", err)
 			}
 		}
-		fmt.Fprintln(cmd.OutOrStderr(), "Installing Kuberik...")
+		_, _ = fmt.Fprintln(cmd.OutOrStderr(), "Installing Kuberik...")
 		url := coreInstallURL
 		args2 := []string{"apply", "-f", url}
 		if bootstrapAll {

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 The Kuberik CRDs and what they do. Field-level reference is generated from the controller source and lives at [kuberik.com/docs/api](https://kuberik.com/docs/api/).
 
 | Kind | Group / Version | Scope | Owner | Purpose |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `Rollout` | `kuberik.com/v1alpha1` | Namespaced | rollout-controller | Drives a release pipeline: tracks one ImagePolicy, evaluates gates and health checks, patches the target Flux resource, bakes |
 | `RolloutGate` | `kuberik.com/v1alpha1` | Namespaced | rollout-controller | Boolean veto on a Rollout (`spec.passing`) |
 | `HealthCheck` | `kuberik.com/v1alpha1` | Namespaced | rollout-controller | Observed health signal read during bake; produced by integration controllers |
@@ -16,7 +16,7 @@ The Kuberik CRDs and what they do. Field-level reference is generated from the c
 ## Annotations the controllers honor
 
 | Annotation | Reads on | Effect |
-|---|---|---|
+| --- | --- | --- |
 | `rollout.kuberik.com/rollout` | `OCIRepository`, `Kustomization` | Marks the resource as the Rollout's target. The controller patches its image tag when a release is promoted. |
 | `rollout.kuberik.com/substitute.<VAR>.from` | `Kustomization` | Patches `spec.postBuild.substitute.<VAR>` with the latest image tag from the named ImagePolicy. |
 | `rollout.kuberik.com/suspended` | `Rollout` | When `true`, the controller pauses promotion without disturbing gate/health evaluation. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,6 @@ Source: [kuberik/rollout-dashboard](https://github.com/kuberik/rollout-dashboard
 ## CRD Ownership
 
 | CRD | Owner |
-|---|---|
+| --- | --- |
 | `Rollout`, `RolloutGate`, `HealthCheck`, `RolloutSchedule`, `ClusterRolloutSchedule` | rollout-controller |
 | `Environment` | environment-controller |

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -16,7 +16,7 @@ helm install kuberik kuberik/kuberik \
 ## CRDs at a glance
 
 | Kind | Group | Scope | Purpose |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `Rollout` | `kuberik.com/v1alpha1` | namespaced | Release pipeline |
 | `RolloutGate` | same | namespaced | Boolean veto on a Rollout |
 | `HealthCheck` | same | namespaced | Bake-period validation signal |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ sudo install bin/kuberik /usr/local/bin/
 ## Global flags
 
 | Flag | Description |
-|---|---|
+| --- | --- |
 | `--kubeconfig` | Path to a kubeconfig file. Defaults to `$KUBECONFIG` or `~/.kube/config`. |
 | `-n, --namespace` | Kubernetes namespace. Defaults to `default`. |
 | `-v, --version` | Print version and exit. |

--- a/docs/gates.md
+++ b/docs/gates.md
@@ -36,7 +36,7 @@ kubectl patch rolloutgate my-app-approval -n production \
 Different controllers create gates for different reasons. The Rollout does not care who set the gate - all it sees is the boolean.
 
 | Source | What it gates on |
-|---|---|
+| --- | --- |
 | Manual | A human (or ChatOps bot) flips `spec.passing` |
 | RolloutSchedule | Time-based: business hours, holiday freezes, maintenance windows |
 | environment-controller | Promotion order: production gates on staging being deployed (`After` relationship) |

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -33,7 +33,7 @@ Key status fields:
 ## Producers
 
 | Controller | What it watches |
-|---|---|
+| --- | --- |
 | datadog-controller | `DatadogMonitor` resources annotated `kuberik.com/health-check: "true"` |
 | prometheus-controller | PromQL queries or alert states |
 | Your custom controller | Anything you can compute - synthetic probes, smoke test job results, dependency dashboards |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ This applies a [kustomize bundle](../config/install/kustomization.yaml) that pin
 ## Components
 
 | Component | Install URL | Required? |
-|---|---|---|
+| --- | --- | --- |
 | rollout-controller | `https://github.com/kuberik/rollout-controller/releases/latest/download/install.yaml` | yes |
 | rollout-dashboard | `https://github.com/kuberik/rollout-dashboard/releases/latest/download/install.yaml` | no |
 | datadog-controller | `https://github.com/kuberik/datadog-controller/releases/latest/download/install.yaml` | no |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -5,7 +5,7 @@ The Kuberik controllers expose Prometheus metrics on port `8080` at `/metrics` (
 ## rollout-controller
 
 | Metric | Type | Labels | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `kuberik_rollout_promotions_total` | counter | `rollout`, `namespace`, `result` (`succeeded`/`failed`) | Number of release promotions attempted |
 | `kuberik_rollout_bake_failures_total` | counter | `rollout`, `namespace`, `reason` | Bake failures by reason (`unhealthy`, `lastErrorTime`, `manual_reject`) |
 | `kuberik_rollout_gate_blocked_seconds` | histogram | `rollout`, `gate`, `namespace` | How long a rollout sat blocked by a specific gate |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,7 +9,7 @@ Argo Rollouts owns the deployment strategy (canary, blue-green) and traffic shif
 These two tools are not direct replacements - many teams run both. A typical layout:
 
 | Argo Rollouts concept | Kuberik analog |
-|---|---|
+| --- | --- |
 | `Rollout` (with strategy.canary/.blueGreen) | Continue using - drives traffic shifting and pod orchestration |
 | `AnalysisTemplate` | `HealthCheck` produced by an integration controller |
 | `AnalysisRun` | `HealthCheck.status` during the bake window |
@@ -24,7 +24,7 @@ Kuberik does not implement traffic-shifting itself. If you already use Argo Roll
 Flagger automates progressive delivery on a single workload: it shifts traffic, runs metric analysis, and rolls back on failure. Kuberik separates these concerns into independent controllers and CRDs:
 
 | Flagger concept | Kuberik analog |
-|---|---|
+| --- | --- |
 | `Canary` resource | Combination of `Rollout` + `HealthCheck` + strategy (e.g. OpenKruise) |
 | Webhook checks | `RolloutGate` produced by a custom controller |
 | Metric template (PromQL / Datadog) | `HealthCheck` from prometheus-controller / datadog-controller |

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -30,7 +30,7 @@ kubectl apply -f kuberik/crds/
 ## Chart -> controller version matrix
 
 | Chart version | rollout-controller | datadog | openkruise | environment | dashboard |
-|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- |
 | 0.2.x | v0.7.0 | v0.1.0 | v0.3.3 | v0.1.5 | v0.7.7 |
 | 0.3.x | v0.7.0 | v0.1.0 | v0.3.3 | v0.1.5 | v0.7.7 |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Copy-pasteable manifests showing common Kuberik configurations. Each subdirectory is a self-contained example.
 
 | Example | What it shows |
-|---|---|
+| --- | --- |
 | [basic-rollout](basic-rollout) | A minimal Rollout tracking one image with a bake period |
 | [with-gate](with-gate) | Adding a manual approval gate to a Rollout |
 | [with-schedule](with-schedule) | Business-hours-only promotions and holiday change freezes |

--- a/examples/with-datadog/README.md
+++ b/examples/with-datadog/README.md
@@ -5,7 +5,7 @@ Use Datadog as a health signal for a Kuberik Rollout. While the signal is health
 Three modes, pick one:
 
 | File | Mode | Requires Datadog Operator? |
-|------|------|------|
+| ------ | ------ | ------ |
 | [monitor.yaml](monitor.yaml) | Annotate a `DatadogMonitor` CRD | Yes |
 | [healthcheck-datadog-api.yaml](healthcheck-datadog-api.yaml) | Poll a monitor via the Datadog API directly | No |
 | [healthcheck-datadog-incidents.yaml](healthcheck-datadog-incidents.yaml) | Go unhealthy while a labeled incident is open | No |

--- a/examples/with-datadog/README.md
+++ b/examples/with-datadog/README.md
@@ -5,7 +5,7 @@ Use Datadog as a health signal for a Kuberik Rollout. While the signal is health
 Three modes, pick one:
 
 | File | Mode | Requires Datadog Operator? |
-| ------ | ------ | ------ |
+| --- | --- | --- |
 | [monitor.yaml](monitor.yaml) | Annotate a `DatadogMonitor` CRD | Yes |
 | [healthcheck-datadog-api.yaml](healthcheck-datadog-api.yaml) | Poll a monitor via the Datadog API directly | No |
 | [healthcheck-datadog-incidents.yaml](healthcheck-datadog-incidents.yaml) | Go unhealthy while a labeled incident is open | No |


### PR DESCRIPTION
## Summary

Supersedes / unblocks https://github.com/kuberik/kuberik/pull/7 by carrying the same CI action bumps plus the two failures that kept it red:

1. **golangci-lint** — action bump to v9 pulls golangci-lint v2, which rejects the empty config `version`. Migrates `.golangci.yml` to v2 (`version: "2"`, formatters split, exclusions).
2. **markdownlint MD060** — padded table separators in `README.md` and `examples/*` (not `docs/upgrade.md` — that stays with #9).

## Test plan

- [ ] CI green on this PR (lint + markdownlint + existing jobs)
- [ ] Close or supersede Dependabot #7 once this merges