### PR TITLE
chore(install): bump openkruise-controller to v0.4.1

### DIFF
--- a/chart/kuberik/templates/integrations-openkruise.yaml
+++ b/chart/kuberik/templates/integrations-openkruise.yaml
@@ -330,7 +330,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: {{ printf "%s:%s" .Values.integrations.openkruise.image.repository (.Values.integrations.openkruise.image.tag | default "v0.4.0") | quote }}
+        image: {{ printf "%s:%s" .Values.integrations.openkruise.image.repository (.Values.integrations.openkruise.image.tag | default "v0.4.1") | quote }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/install/kustomization.yaml
+++ b/config/install/kustomization.yaml
@@ -15,6 +15,6 @@ resources:
   - https://github.com/kuberik/rollout-controller/releases/download/v0.8.0/install.yaml
 
   # Integrations (optional - comment out what you don't need)
-  - https://github.com/kuberik/openkruise-controller/releases/download/v0.4.0/install.yaml
+  - https://github.com/kuberik/openkruise-controller/releases/download/v0.4.1/install.yaml
   - https://github.com/kuberik/datadog-controller/releases/download/v0.1.0/install.yaml
   - https://github.com/kuberik/environment-controller/releases/download/v0.1.5/install.yaml


### PR DESCRIPTION
## Summary
Bump `openkruise-controller` **v0.4.0 → v0.4.1** (same pattern as #8 / issue #5):

- `config/install/kustomization.yaml` release URL
- `chart/kuberik/templates/integrations-openkruise.yaml` default image tag

Verified release asset: https://github.com/kuberik/openkruise-controller/releases/download/v0.4.1/install.yaml

Fixes #11

## Test plan
- [ ] Release asset reachable at the new URL
- [ ] `kubectl kustomize config/install` resolves the updated remote resource
