### PR TITLE
chore(install): bump rollout-controller to v0.9.1

### DIFF
--- a/chart/kuberik/Chart.yaml
+++ b/chart/kuberik/Chart.yaml
@@ -3,7 +3,7 @@ name: kuberik
 description: Kubernetes-native progressive delivery. Installs the Kuberik rollout-controller and optional integration controllers.
 type: application
 version: 0.5.1
-appVersion: "0.9.0"
+appVersion: "0.9.1"
 home: https://kuberik.com
 sources:
   - https://github.com/kuberik/kuberik

--- a/chart/kuberik/Chart.yaml
+++ b/chart/kuberik/Chart.yaml
@@ -3,7 +3,7 @@ name: kuberik
 description: Kubernetes-native progressive delivery. Installs the Kuberik rollout-controller and optional integration controllers.
 type: application
 version: 0.5.1
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 home: https://kuberik.com
 sources:
   - https://github.com/kuberik/kuberik

--- a/config/install/kustomization.yaml
+++ b/config/install/kustomization.yaml
@@ -12,7 +12,7 @@ kind: Kustomization
 
 resources:
   # Core (required)
-  - https://github.com/kuberik/rollout-controller/releases/download/v0.9.0/install.yaml
+  - https://github.com/kuberik/rollout-controller/releases/download/v0.9.1/install.yaml
 
   # Integrations (optional - comment out what you don't need)
   - https://github.com/kuberik/openkruise-controller/releases/download/v0.4.0/install.yaml

--- a/config/install/kustomization.yaml
+++ b/config/install/kustomization.yaml
@@ -12,7 +12,7 @@ kind: Kustomization
 
 resources:
   # Core (required)
-  - https://github.com/kuberik/rollout-controller/releases/download/v0.8.0/install.yaml
+  - https://github.com/kuberik/rollout-controller/releases/download/v0.9.0/install.yaml
 
   # Integrations (optional - comment out what you don't need)
   - https://github.com/kuberik/openkruise-controller/releases/download/v0.4.0/install.yaml


### PR DESCRIPTION
## Summary
Bump `rollout-controller` **v0.8.0 → v0.9.1** (retargeted from v0.9.0):

- `config/install/kustomization.yaml` release URL
- `chart/kuberik/Chart.yaml` `appVersion` (`"0.8.0"` → `"0.9.1"`) — chart image helper uses `v` + AppVersion when tag is empty

Left chart `version` at `0.5.1` (no chart cut). Did **not** touch `docs/upgrade.md` — Docs owns the matrix row after the chart is cut.

Verified release asset: https://github.com/kuberik/rollout-controller/releases/download/v0.9.1/install.yaml

## Test plan
- [ ] Release asset reachable
- [ ] `kubectl kustomize config/install` resolves the updated remote resource
- [ ] Helm default image resolves to `ghcr.io/kuberik/rollout-controller:v0.9.1`
